### PR TITLE
Ignore SIGPIPE for SSL connections on Linux

### DIFF
--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -24,6 +24,7 @@ import Socket
 
 #if os(Linux)
 	import OpenSSL
+	import Glibc
 #endif
 
 import Dispatch
@@ -381,6 +382,12 @@ public class SSLService: SSLServiceDelegate {
 				OPENSSL_add_all_algorithms_conf()
 				SSLService.initialized = true
 			}
+
+			// On Linux, it is not possible to set SO_NOSIGPIPE on the socket, nor
+			// is it possible to pass MSG_NOSIGNAL when writing via SSL_write().
+			// Instead, we will receive but ignore SIGPIPE in instances where a
+			// remote receiver closes their socket while we are trying to write.
+			signal(SIGPIPE, SIG_IGN)
 			
 			// Server or client specific method determination...
 			if isServer {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On Linux, it is not possible to set SO_NOSIGPIPE on the socket, nor is it possible to pass MSG_NOSIGNAL when writing via SSL_write().
Instead, we will receive but ignore SIGPIPE in instances where a remote receiver closes their socket while we are trying to write.

## Motivation and Context
Resolves #13

Although setting the signal handler is global to the process, by doing so in `SSLService.initialize()` we restrict it to being applied only in cases where a process is actively using SSL.

## How Has This Been Tested?
I re-ran a Kitura SSL application under load.  I no longer see process termination due to an unhandled SIGPIPE.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
