### PR TITLE
IBM-Swift/Kitura#1036 throw SSLError.retryNeeded on errSSLWouldBlock

### DIFF
--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -562,8 +562,9 @@ public class SSLService: SSLServiceDelegate {
 				
 				var processed = 0
 				let status: OSStatus = SSLWrite(sslContext, buffer, bufSize, &processed)
-				if status != errSecSuccess && status != errSSLWouldBlock {
-					
+				if status == errSSLWouldBlock {
+					throw SSLError.retryNeeded
+				} else if status != errSecSuccess {
 					try self.throwLastError(source: "SSLWrite", err: status)
 				}
 				return processed


### PR DESCRIPTION
## Description
Sending files larger than approximately 256k using SSLService currently fails because it is not retrying after status errSSLWouldBlock from SSLWrite().

## Motivation and Context
IBM-Swift/Kitura#1036

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
