### PR TITLE
Use SSL_get_error, not SSL_write rc for SSL_ERROR_WANT_* check

### DIFF
--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -537,7 +537,8 @@ public class SSLService: SSLServiceDelegate {
 				let rc = SSL_write(sslConnect, buffer, Int32(bufSize))
 				if rc < 0 {
 				
-					if rc == SSL_ERROR_WANT_READ || rc == SSL_ERROR_WANT_WRITE {
+					let error = SSL_get_error(sslConnect, rc)
+					if error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE {
 					
 						throw SSLError.retryNeeded
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Based on OpenSSL documentation, when `SSL_write` and `SSL_read` return a negative return code, we should use `SSL_get_error` to get the error code to compare with SSL_ERROR_WANT_READ and SSL_ERROR_WANT_READ.

Testing SSL_ERROR_WANT_READ and SSL_ERROR_WANT_READ (which are both positive values) against a negative return value of `SSL_write` and `SSL_read` will never return true.

This same change also needs to be done in `SSLService.recv()` after `SSL_read`. But when I tried that, `Socket.isReadableOrWritable()` kept returning false and so `wait(forRead:)` looped forever and caused the request to hang. It probably needs some additional fixes there before the `SSLService.recv()` fix can be done.

## Motivation and Context
IBM-Swift/Kitura#1036

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
