### PR TITLE
Add an option to allow clients to connect to servers that are self-signed

### DIFF
--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -28,10 +28,6 @@ import Socket
 
 import Dispatch
 
-/// Returned instead of errSecSuccess when client accepts self-signed certificates and authentication completed successfully
-let errSSLServerAuthCompleted: OSStatus = -9841
-
-
 // MARK: SSLService
 
 ///
@@ -74,7 +70,7 @@ public class SSLService: SSLServiceDelegate {
 			errSecAuthFailed    	 : "errSecAuthFailed",
 			errSSLClosedGraceful	 : "errSSLClosedGraceful",
 			errSSLXCertChainInvalid	 : "errSSLXCertChainInvalid",
-			errSSLServerAuthCompleted: "errSSLServerAuthCompleted"
+			errSSLPeerAuthCompleted: "errSSLPeerAuthCompleted"
 		]
 	
 	#endif
@@ -1092,7 +1088,7 @@ public class SSLService: SSLServiceDelegate {
 			
 		} while status == errSSLWouldBlock
 		
-		if status != errSecSuccess && status != errSSLServerAuthCompleted {
+		if status != errSecSuccess && status != errSSLPeerAuthCompleted {
 			
 			try self.throwLastError(source: "SSLHandshake", err: status)
 		}

--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -28,6 +28,10 @@ import Socket
 
 import Dispatch
 
+/// Returned instead of errSecSuccess when client accepts self-signed certificates and authentication completed successfully
+let errSSLServerAuthCompleted: OSStatus = -9841
+
+
 // MARK: SSLService
 
 ///
@@ -59,17 +63,18 @@ public class SSLService: SSLServiceDelegate {
 	
 		/// String representation of Secure Transport Errors
 		let SecureTransportErrors: [OSStatus: String] 	= [
-			errSecSuccess       	: "errSecSuccess",
-			errSSLNegotiation   	: "errSSLNegotiation",
-			errSecParam         	: "errSecParam",
-			errSSLClosedAbort   	: "errSSLClosedAbort",
-			errSecIO            	: "errSecIO",
-			errSSLWouldBlock    	: "errSSLWouldBlock",
-			errSSLPeerUnknownCA 	: "errSSLPeerUnknownCA",
-			errSSLBadRecordMac  	: "errSSLBadRecordMac",
-			errSecAuthFailed    	: "errSecAuthFailed",
-			errSSLClosedGraceful	: "errSSLClosedGraceful",
-			errSSLXCertChainInvalid	: "errSSLXCertChainInvalid"
+			errSecSuccess       	 : "errSecSuccess",
+			errSSLNegotiation   	 : "errSSLNegotiation",
+			errSecParam         	 : "errSecParam",
+			errSSLClosedAbort   	 : "errSSLClosedAbort",
+			errSecIO            	 : "errSecIO",
+			errSSLWouldBlock    	 : "errSSLWouldBlock",
+			errSSLPeerUnknownCA 	 : "errSSLPeerUnknownCA",
+			errSSLBadRecordMac  	 : "errSSLBadRecordMac",
+			errSecAuthFailed    	 : "errSecAuthFailed",
+			errSSLClosedGraceful	 : "errSSLClosedGraceful",
+			errSSLXCertChainInvalid	 : "errSSLXCertChainInvalid",
+			errSSLServerAuthCompleted: "errSSLServerAuthCompleted"
 		]
 	
 	#endif
@@ -138,8 +143,11 @@ public class SSLService: SSLServiceDelegate {
 		/// Path to PEM formatted certificate string.
 		public private(set) var certificateString: String? = nil
 		
-		/// True if using `self-signed` certificates.
+		/// True if server is using `self-signed` certificates.
 		public private(set) var certsAreSelfSigned = false
+        
+        /// True if isServer == false and the client accepts self-signed certificates. Defaults to false, be careful to not leave as true in production
+        public private(set) var clientAllowsSelfSignedCertificates = false
 		
 		#if os(Linux)
 			/// Cipher suites to use. Defaults to `DEFAULT`
@@ -218,18 +226,20 @@ public class SSLService: SSLServiceDelegate {
 		/// *Note:* If using a certificate chain file, the certificates must be in PEM format and must be sorted starting with the subject's certificate (actual client or server certificate), followed by intermediate CA certificates if applicable, and ending at the highest level (root) CA.
 		///
 		/// - Parameters:
-		///		- chainFilePath:			Path to the certificate chain file (optional). *(see note above)*
-		///		- password:					Password for the chain file (optional).
-		///		- selfSigned:				True if certs are `self-signed`, false otherwise. Defaults to true.
-		///		- cipherSuite:				Optional String containing the cipher suite to use.
+		///		- chainFilePath:                        Path to the certificate chain file (optional). *(see note above)*
+		///		- password:                             Password for the chain file (optional).
+		///		- selfSigned:                           True if certs are `self-signed`, false otherwise. Defaults to true.
+        ///     - clientAllowsSelfSignedCertificates:   True if, as a client, connections to self-signed servers are allowed
+		///		- cipherSuite:                          Optional String containing the cipher suite to use.
 		///
 		///	- Returns:	New Configuration instance.
 		///
-		public init(withChainFilePath chainFilePath: String? = nil, withPassword password: String? = nil, usingSelfSignedCerts selfSigned: Bool = true, cipherSuite: String? = nil) {
+        public init(withChainFilePath chainFilePath: String? = nil, withPassword password: String? = nil, usingSelfSignedCerts selfSigned: Bool = true, clientAllowsSelfSignedCertificates: Bool = false, cipherSuite: String? = nil) {
 			
 			self.certificateChainFilePath = chainFilePath
 			self.password = password
 			self.certsAreSelfSigned = selfSigned
+            self.clientAllowsSelfSignedCertificates = clientAllowsSelfSignedCertificates
 			if cipherSuite != nil {
 				self.cipherSuite = cipherSuite!
 			}
@@ -676,7 +686,7 @@ public class SSLService: SSLServiceDelegate {
 			}
 			return
 		}
-		
+        
 		#if os(Linux)
 			
 			// If we're using self-signed certs, we only require a certificate and key...
@@ -1068,6 +1078,12 @@ public class SSLService: SSLServiceDelegate {
 			
 			try self.throwLastError(source: "SSLSetConnection", err: status)
 		}
+        
+        // Allow self signed certificates from server
+        if isServer == false && configuration.clientAllowsSelfSignedCertificates == true {
+            SSLSetSessionOption(sslContext, .breakOnServerAuth, true)
+        }
+
 		
 		// Start and repeat the handshake process until it either completes or fails...
 		repeat {
@@ -1076,7 +1092,7 @@ public class SSLService: SSLServiceDelegate {
 			
 		} while status == errSSLWouldBlock
 		
-		if status != errSecSuccess {
+		if status != errSecSuccess && status != errSSLServerAuthCompleted {
 			
 			try self.throwLastError(source: "SSLHandshake", err: status)
 		}


### PR DESCRIPTION
While developing Bolt-swift, I needed to connect via SSL to a server instance running on my laptop that used a self-signed certificate. This adds support for that in BlueSSLService

It has so far only been tested by me with the Neo4j server on my local machine

- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.