### PR TITLE
Added Podspec

### DIFF
--- a/BlueSSLService.podspec
+++ b/BlueSSLService.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name        = "BlueSSLService"
+  s.version     = "0.12.33"
+  s.summary     = "SSL/TLS Add-in framework for BlueSocket in Swift"
+  s.homepage    = "https://github.com/IBM-Swift/BlueSSLService"
+  s.license     = { :type => "Apache License, Version 2.0" }
+  s.author     = "IBM"
+  s.module_name  = 'SSLService'
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.11"
+  s.ios.deployment_target = "10.0"
+  s.source   = { :git => "https://github.com/IBM-Swift/BlueSSLService.git", :tag => s.version }
+  s.source_files = "Sources/*.swift"
+  s.dependency 'BlueSocket', '~> 0.12.49'
+  s.pod_target_xcconfig =  {
+        'SWIFT_VERSION' => '3.1',
+  }
+end


### PR DESCRIPTION
Added podspec similar to the one in the BlueSocket repo. As soon as the BlueSocket one is submitted to the cocoapods repo, I expect this pod to work.

My motivation is that me and some friends maintain Theo (https://github.com/graphstory/neo4j-ios), the neo4j swift driver. With its version 3.1, it adds Bolt support through BoltProtocol (https://github.com/niklassaers/Bolt-swift). We want to maintain Cocoapods support, and since BoltProtocol has a dependency on BlueSSLService and BlueSocket, we need published podspec for them. I've tried them both out under iOS, and looks good to me, so I expect they're good to publish. :-) When BlueSocket is published on CocoaPods, I'll do a validation that this pod indeed works there before we mere

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.