### PR TITLE
Fix index out of bounds issue on items

### DIFF
--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -966,9 +966,9 @@ public class SSLService: SSLServiceDelegate {
 					
 					// 	- Now extract what we need...
                     let newArray = items! as [AnyObject] as NSArray
-                    if newArray.count == 0 {
-                        let reason = "ERROR: Could not load content of PKCS12 file"
-                        throw SSLError.fail(Int(ENOENT), reason)
+					if newArray.count == 0 {
+						let reason = "ERROR: Could not load content of PKCS12 file"
+						throw SSLError.fail(Int(ENOENT), reason)
                     }
 					let dictionary = newArray.object(at: 0)
 					

--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -965,11 +965,11 @@ public class SSLService: SSLServiceDelegate {
 					}
 					
 					// 	- Now extract what we need...
-                    let newArray = items! as [AnyObject] as NSArray
+					let newArray = items! as [AnyObject] as NSArray
 					if newArray.count == 0 {
 						let reason = "ERROR: Could not load content of PKCS12 file"
 						throw SSLError.fail(Int(ENOENT), reason)
-                    }
+					}
 					let dictionary = newArray.object(at: 0)
 					
 					//	-- Identity reference...

--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -965,7 +965,11 @@ public class SSLService: SSLServiceDelegate {
 					}
 					
 					// 	- Now extract what we need...
-					let newArray = items! as [AnyObject] as NSArray
+                    let newArray = items! as [AnyObject] as NSArray
+                    if newArray.count == 0 {
+                        let reason = "ERROR: Could not load content of PKCS12 file"
+                        throw SSLError.fail(Int(ENOENT), reason)
+                    }
 					let dictionary = newArray.object(at: 0)
 					
 					//	-- Identity reference...


### PR DESCRIPTION
I have a case where items becomes empty, even though p12Data contains data, passwd is correct, and status returns 0. I believe the case is when I'm running as a user who isn't logged in on the system at the moment, because the user it's happening for is "jenkins". Will investigate that further, but the consequence of this is that "newArray.object(at: 0)" would become an index out of bounds error. So this PR tests for that and provides an error instead

Sorry about the indentation-nonsense in the commits.

- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.