### PR TITLE
Retry on Abort

### DIFF
--- a/Sources/SSLService.swift
+++ b/Sources/SSLService.swift
@@ -1203,7 +1203,7 @@ public class SSLService: SSLServiceDelegate {
 			
 			status = SSLHandshake(sslContext)
 			
-		} while status == errSSLWouldBlock
+		} while status == errSSLWouldBlock || status == errSSLClosedAbort
 		
 		if status != errSecSuccess && status != errSSLPeerAuthCompleted {
 			


### PR DESCRIPTION
For some reason I get very frequent aborts, but on retry I don’t get it. For reference, the server I used for testing was:

“openssl s_server -accept 3333 -cert cert.pem -certform PEM -key key.pem -keyform PEM -debug”

With this check and repeat, it works

In tandem with Bills update for public init(withCipherSuite cipherSuite: String? = nil, clientAllowsSelfSignedCertificates: Bool = true), this closes https://github.com/IBM-Swift/BlueSSLService/issues/28

- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.