### PR TITLE
Correct error handling for SSL_ERROR_SSL

### DIFF
--- a/Sources/SSLService/SSLService.swift
+++ b/Sources/SSLService/SSLService.swift
@@ -490,6 +490,7 @@ public class SSLService: SSLServiceDelegate {
 				let sslConnect = try prepareConnection(socket: socket)
 				
 				// Start the handshake...
+				ERR_clear_error()
 				let rc = SSL_accept(sslConnect)
 				if rc <= 0 {
 					
@@ -527,6 +528,7 @@ public class SSLService: SSLServiceDelegate {
 			let sslConnect = try prepareConnection(socket: socket)
 			
 			// Start the handshake...
+			ERR_clear_error()
 			let rc = SSL_connect(sslConnect)
 			if rc <= 0 {
 				
@@ -565,6 +567,7 @@ public class SSLService: SSLServiceDelegate {
 					throw SSLError.fail(Int(ECONNABORTED), reason)
 				}
 			
+				ERR_clear_error()
 				let rc = SSL_write(sslConnect, buffer, Int32(bufSize))
 				if rc < 0 {
 				
@@ -631,6 +634,7 @@ public class SSLService: SSLServiceDelegate {
 					throw SSLError.fail(Int(ECONNABORTED), reason)
 				}
 			
+				ERR_clear_error()
 				let rc = SSL_read(sslConnect, buffer, Int32(bufSize))
 				if rc < 0 {
 				

--- a/Sources/SSLService/SSLService.swift
+++ b/Sources/SSLService/SSLService.swift
@@ -1308,7 +1308,7 @@ public class SSLService: SSLServiceDelegate {
 		
 		#if os(Linux)
 			
-			if errorCode == 0 {
+			if errorCode == 0 || errorCode == SSL_ERROR_SSL {
 				errorCode = Int32(ERR_get_error())
 			}
 			
@@ -1320,6 +1320,10 @@ public class SSLService: SSLServiceDelegate {
 			
 			if let errorStr = ERR_reason_error_string(UInt(errorCode)) {
 				errorString = String(validatingUTF8: errorStr)!
+
+				if let errorFunc = ERR_func_error_string(UInt(errorCode)) {
+					errorString = String(validatingUTF8: errorFunc)! + ":" + errorString
+				}
 			} else {
 				errorString = "Could not determine error reason."
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes two things in the Linux (openssl) implementation:
- Inserts missing calls to `ERR_clear_error` prior to functions that may require `SSL_get_error` to be called
- Corrects the logic for obtaining the detailed error description for the `SSL_ERROR_SSL` case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves an intermittent failure exposed by a test added to Kitura-net (https://github.com/IBM-Swift/Kitura-net/pull/219), where the test can cause an SSL protocol error (`SSL_ERROR_SSL`).

When this occurs, an error is placed onto that thread's error queue, however the `throwLastError` function did not call `ERR_get_error` in this case, instead reporting "Could not determine error reason." and leaving the error on the queue.

The next SSL call with a non-zero return on that thread would then trigger a call to `SSL_get_error`, which would incorrectly pick up the error on the queue, incorrectly reporting another `SSL_ERROR_SSL`.

Part of the contract of `SSL_get_error` is that the error queue must have been cleared before a call to `SSL_read`, `SSL_accept`, etc. is made.  To ensure we obey this contract, I have added `ERR_clear_error` before each such call.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have run the Kitura-net tests and they pass.

Since we do not have a test that deliberately or reliably causes an SSL protocol error,  to test the output of the error reporting,  I modified a test locally to remove the SSL delegate from the client-side socket and then send some erroneous data.  This results in the following output:
```
[ERROR] [IncomingSocketHandler.swift:153 handleRead()] Read from socket (file descriptor 15) failed. Error = Error code: 336130315(0x1408F10B), ERROR: SSL_read, code: 336130315, reason: SSL3_GET_RECORD:wrong version number.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
