### PR TITLE
Adds ALPN support on macOS 10.13+, iOS/tvOS 11+, and watchOS 4+

### DIFF
--- a/Sources/SSLService/SSLService.swift
+++ b/Sources/SSLService/SSLService.swift
@@ -324,21 +324,6 @@ public class SSLService: SSLServiceDelegate {
 		/// SSL Context
 		public private(set) var context: UnsafeMutablePointer<SSL_CTX>? = nil
 	
-	
-		// MARK: ALPN
-		
-		/// List of supported ALPN protocols
-		public func addSupportedAlpnProtocol(proto: String) {
-			if SSLService.availableAlpnProtocols.contains(proto) {
-				return
-			}
-			SSLService.availableAlpnProtocols.append(proto)
-		}
-		private static var availableAlpnProtocols = [String]()
-		
-		/// The negotiated ALPN protocol, if any
-		public private(set) var negotiatedAlpnProtocol: String?
-	
 	#else
 	
 		/// Socket Pointer containing the socket fd (passed to the `SSLRead` and `SSLWrite` callback routines).
@@ -348,6 +333,38 @@ public class SSLService: SSLServiceDelegate {
 		public private(set) var context: SSLContext?
 	
 	#endif
+    
+    // MARK: ALPN
+    
+    /// List of supported ALPN protocols
+    public func addSupportedAlpnProtocol(proto: String) {
+        #if !os(Linux)
+            // macOS/iOS provide access to ALPN in SecureTransport as of 10.13/11.0, etc.
+            guard #available(macOS 10.13, iOS 11.0, tvOS 11.0, *) else { return }
+        #endif
+        
+        if SSLService.availableAlpnProtocols.contains(proto) {
+            return
+        }
+        SSLService.availableAlpnProtocols.append(proto)
+    }
+    private static var availableAlpnProtocols = [String]()
+    
+    /// The negotiated ALPN protocol, if any
+    public private(set) var negotiatedAlpnProtocol: String?
+    
+    public static var isAlpnSupported: Bool {
+        #if os(Linux)
+            return true
+        #else
+            if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+                return true
+            }
+            else {
+                return false
+            }
+        #endif
+    }
 	
 	// MARK: Lifecycle
 	
@@ -499,7 +516,8 @@ public class SSLService: SSLServiceDelegate {
 				
 			#else
 				
-				// Prepare the connection and start the handshake process...
+				// Prepare the connection and start the handshake process.
+                // This will supply our ALPN protocols to SecureTransport for negotiation.
 				try prepareConnection(socket: socket)
 				
 			#endif
@@ -1198,7 +1216,10 @@ public class SSLService: SSLServiceDelegate {
         if isServer == false && configuration.clientAllowsSelfSignedCertificates == true {
             SSLSetSessionOption(sslContext, .breakOnServerAuth, true)
         }
-
+        
+        if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+            try setAlpnProtocols(on: sslContext)
+        }
 		
 		// Start and repeat the handshake process until it either completes or fails...
 		repeat {
@@ -1211,7 +1232,50 @@ public class SSLService: SSLServiceDelegate {
 			
 			try self.throwLastError(source: "SSLHandshake", err: status)
 		}
+        
+        if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+            completeAlpnProtocolNegotiation(on: sslContext)
+        }
 	}
+    
+    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+    private func setAlpnProtocols(on sslContext: SSLContext) throws {
+        
+        guard !SSLService.availableAlpnProtocols.isEmpty else { return }
+        
+        // Tell SecureTransport about our chosen protocols.
+        // It expects a CFArray of CFStrings, which are all bridgable from [String].
+        let cfStrings = SSLService.availableAlpnProtocols as [CFString]
+        let cfArray = cfStrings as CFArray
+        
+        let status: OSStatus = SSLSetALPNProtocols(sslContext, cfArray)
+        if status != errSecSuccess {
+            try self.throwLastError(source: "SSLSetALPNProtocols", err: status)
+        }
+    }
+    
+    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+    private func completeAlpnProtocolNegotiation(on sslContext: SSLContext) {
+        
+        guard !SSLService.availableAlpnProtocols.isEmpty else { return }
+        
+        // Look at the protocols handed back from the peer and find a match.
+        var peerProtocols: Unmanaged<CFArray>? = nil
+        let status: OSStatus = SSLCopyALPNProtocols(sslContext, &peerProtocols)
+        
+        // Should we fail completely if we couldn't pull the list?
+        // Dealing with CFArrays of CFStrings is rather a pain in the `as`...
+        guard let protocolsNS = peerProtocols?.takeRetainedValue() as NSArray?, status == errSecSuccess else { return }
+        let protocols = protocolsNS as! [CFString]
+        for protoCF in protocols {
+            let protoName = protoCF as String
+            
+            if (SSLService.availableAlpnProtocols.contains(protoName)) {
+                negotiatedAlpnProtocol = protoName
+                break
+            }
+        }
+    }
 	
 #endif
 	


### PR DESCRIPTION
Adds support for ALPN using the new SecureTransport APIs in the fall 2017 OS releases.

## Description
I've made the static & member ALPN-related variables available to all, not just Linux, and I've added a static Boolean variable which can be used to check whether ALPN is available at all. On Linux it returns `true`, on Apple platforms it returns `true` only if on 10.13/11.0/4.0 or above, via the Swift `#available()` expression.

Most of the work happens in two new private Apple-only functions, marked as `@available` only on the above OS revisions. Before the call to `SSLHandshake()` we take the available ALPN protocols and attach them to the context via `SSLSetALPNProtocols()`. After the handshake completes, we scan the list from the peer via `SSLCopyALPNProtocols()`, comparing against our list. The first match is set as our `negotiatedALPNProtocol`.

## Motivation and Context
This should enable the Kitura HTTP2 module to function correctly on macOS and friends, since at present it's Linux-only due to the lack of ALPN.

## How Has This Been Tested?
I have no idea how to test this. Apparently there are no unit tests for this project at all? Perhaps someone who's tested the Linux ALPN code can point me at something they used for that?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.