### PR TITLE
Support SSL_OP* constants defined as longs

### DIFF
--- a/Sources/SSLService/SSLService.swift
+++ b/Sources/SSLService/SSLService.swift
@@ -858,7 +858,7 @@ public class SSLService: SSLServiceDelegate {
 			// Then handle the client/server specific stuff...
 			if !self.isServer {
 				
-				SSL_CTX_ctrl(context, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION, nil)
+				SSL_CTX_ctrl(context, SSL_CTRL_OPTIONS, CLong(SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION), nil)
 			}
 			
 			// Now configure the rest...


### PR DESCRIPTION
On Ubuntu 14.04 LTS, the default openssl library has the SSL_OP* constants defined as longs. BlueService fails to compile with this compilation problem:

```
/tmp/.nio-release-tools_nMOEX8/Kitura-NIO/.build/checkouts/BlueSSLService.git--319300084649188933/Sources/SSLService/SSLService.swift:861:79: error: cannot convert value of type 'Int32' to expected argument type 'Int'
                                SSL_CTX_ctrl(context, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION, nil)
                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
                                                                        Int(                                                     )
error: terminated(1): /usr/bin/swift-build-tool -f /tmp/.nio-release-tools_nMOEX8/Kitura-NIO/.build/debug.yaml main output:
```
## Description
The SSL_OP* constants may be defined as longs. `SSLService.swift:861` seems to be the only place where they are referenced. Though the compiler suggests a cast to `Int`, `CLong` makes more sense 
because it is exactly what `long`  is in C.

## Motivation and Context
The `swift-nio` team would want add `Kitura-NIO` tests,  to their release tools. This bug blocks them on Ubuntu 14.04.

## How Has This Been Tested?


## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.