### PR TITLE
Fix: remove @available annotations

### DIFF
--- a/Sources/SSLService/SSLService.swift
+++ b/Sources/SSLService/SSLService.swift
@@ -185,9 +185,6 @@ public class SSLService: SSLServiceDelegate {
 		///
 		///	- Returns:	New Configuration instance.
 		///
-		@available(macOS, unavailable, message: "This API not supported on Apple platforms.")
-		@available(iOS, unavailable, message: "This API not supported on Apple platforms.")
-		@available(tvOS, unavailable, message: "This API not supported on Apple platforms.")
 		public init(withCipherSuite cipherSuite: String? = nil, clientAllowsSelfSignedCertificates: Bool = true) {
 			
 			self.noBackingCertificates = true
@@ -209,9 +206,6 @@ public class SSLService: SSLServiceDelegate {
 		///
 		///	- Returns:	New Configuration instance.
 		///
-		@available(macOS, unavailable, message: "This API not supported on Apple platforms.")
-		@available(iOS, unavailable, message: "This API not supported on Apple platforms.")
-		@available(tvOS, unavailable, message: "This API not supported on Apple platforms.")
 		public init(withCACertificateFilePath caCertificateFilePath: String?, usingCertificateFile certificateFilePath: String?, withKeyFile keyFilePath: String? = nil, usingSelfSignedCerts selfSigned: Bool = true, cipherSuite: String? = nil) {
 			
 			self.certificateFilePath = certificateFilePath
@@ -237,9 +231,6 @@ public class SSLService: SSLServiceDelegate {
 		///
 		///	- Returns:	New Configuration instance.
 		///
-		@available(macOS, unavailable, message: "This API not supported on Apple platforms.")
-		@available(iOS, unavailable, message: "This API not supported on Apple platforms.")
-		@available(tvOS, unavailable, message: "This API not supported on Apple platforms.")
 		public init(withCACertificateDirectory caCertificateDirPath: String?, usingCertificateFile certificateFilePath: String?, withKeyFile keyFilePath: String? = nil, usingSelfSignedCerts selfSigned: Bool = true, cipherSuite: String? = nil) {
 			
 			self.certificateFilePath = certificateFilePath


### PR DESCRIPTION
The recently added @available annotations are breaking consumers which include the code in their build.

https://github.com/IBM-Swift/Swift-SMTP/blob/ec3fa120e5d1563105d00bd24b7dfc1b81695eee/Sources/SwiftSMTP/TLSConfiguration.swift#L21

https://github.com/IBM-Swift/Kitura-NIO/blob/2b835e84172b5100f0d122bcf80fab05a0786fc2/Tests/KituraNetTests/KituraNIOTest.swift#L54

As removing APIs cannot be done under SemVer patch - revert this.