### PR TITLE
Update minimum IBM-Swift/OpenSSL version to 2.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ var targetDependencies: [Target.Dependency] = [.byName(name: "Socket")]
 
 #if os(Linux)
 
-	packageDependencies.append(.package(url: "https://github.com/IBM-Swift/OpenSSL.git", from: "2.0.0"))
+	packageDependencies.append(.package(url: "https://github.com/IBM-Swift/OpenSSL.git", from: "2.2.0"))
 
 	targetDependencies.append(.byName(name: "OpenSSL"))
 


### PR DESCRIPTION
Currently, BlueSSLService specifies minimum version of 2.0.0 for OpenSSL.

Because BlueCryptor specifies a minimum of 2.2 (https://github.com/IBM-Swift/BlueCryptor/commit/448f30bcc8b254e13b8044958debb347d77bc791) this can cause package resolution to "hang" due to problems with SPM's graph resolution implementation.

Increase the minimum to 2.2.0 to match.