### PR TITLE
fix: Resolve compilation warning with Swift 5.1

### DIFF
--- a/Sources/SSLService/SSLService.swift
+++ b/Sources/SSLService/SSLService.swift
@@ -1092,7 +1092,7 @@ public class SSLService: SSLServiceDelegate {
 					
 					//	-- Cert chain...
 					var certs = [secIdentity]
-					var ccerts: Array<SecCertificate> = (dictionary as AnyObject).value(forKey: kSecImportItemCertChain as String) as! Array<SecCertificate>
+					let ccerts: Array<SecCertificate> = (dictionary as AnyObject).value(forKey: kSecImportItemCertChain as String) as! Array<SecCertificate>
 					for i in 1 ..< ccerts.count {
 						
 						certs += [ccerts[i] as AnyObject]


### PR DESCRIPTION
Resolves a compiler warning with Swift 5.1 due to a `var` that was never mutated.